### PR TITLE
Reference recoding of 2nd edition

### DIFF
--- a/chapters/08-next.Rmd
+++ b/chapters/08-next.Rmd
@@ -16,4 +16,4 @@ This book is far from a complete guide to R. But it can continue to be a referen
 <br/>
 :::
 
-[![Statistical Rethinking](images/statistical_rethinking.png){.book_cover style="width: 200px;"}](https://bookdown.org/ajkurz/Statistical_Rethinking_recoded/) If you want to learn Bayesian statistics and modelling, [Statistical Rethinking recoded](https://bookdown.org/ajkurz/Statistical_Rethinking_recoded/) is highly recommended. The original book, [Statistical Rethinking](http://xcelab.net/rm/statistical-rethinking/), teaches with base-R examples, and Statistical Rethinking recoded has updated the book's examples for the tidyverse.
+[![Statistical Rethinking](images/statistical_rethinking.png){.book_cover style="width: 200px;"}](https://bookdown.org/ajkurz/Statistical_Rethinking_recoded/) If you want to learn Bayesian statistics and modelling, [Statistical Rethinking recoded](https://bookdown.org/content/3686/) is highly recommended. The original book, [Statistical Rethinking](http://xcelab.net/rm/statistical-rethinking/), teaches with base-R examples, and Statistical Rethinking recoded has updated the book's examples for the tidyverse.

--- a/chapters/08-next.Rmd
+++ b/chapters/08-next.Rmd
@@ -16,4 +16,4 @@ This book is far from a complete guide to R. But it can continue to be a referen
 <br/>
 :::
 
-[![Statistical Rethinking](images/statistical_rethinking.png){.book_cover style="width: 200px;"}](https://bookdown.org/ajkurz/Statistical_Rethinking_recoded/) If you want to learn Bayesian statistics and modelling, [Statistical Rethinking recoded](https://bookdown.org/content/3686/) is highly recommended. The original book, [Statistical Rethinking](http://xcelab.net/rm/statistical-rethinking/), teaches with base-R examples, and Statistical Rethinking recoded has updated the book's examples for the tidyverse.
+[![Statistical Rethinking](images/statistical_rethinking.png){.book_cover style="width: 200px;"}](https://bookdown.org/ajkurz/Statistical_Rethinking_recoded/) If you want to learn Bayesian statistics and modelling, [Statistical Rethinking recoded](https://bookdown.org/content/3890/) is highly recommended. The original book, [Statistical Rethinking](http://xcelab.net/rm/statistical-rethinking/), teaches with base-R examples, and Statistical Rethinking recoded has updated the book's examples for the tidyverse.


### PR DESCRIPTION
This commit updates the link to the recoding of _Statistical Rethinking_ to the 2nd edition. If you want to keep the reference to the recoding of the 1st edition, you could still consider referencing version 1.2.0 of Kurz' recoding: https://bookdown.org/content/3890/